### PR TITLE
Fix SKILL.md frontmatter for skills CLI compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,33 @@ Best practices for NetBox API integrations, available for multiple AI coding ass
 | Audience | Start Here |
 |----------|------------|
 | **Engineers** | [HUMAN.md](./HUMAN.md) - Best practices guide |
-| **Claude Code users** | Skills auto-discovered from `skills/` directory |
-| **Cursor IDE users** | Rules in `.cursor/rules/` directory |
+| **Claude Code users** | Install skills (see below) |
+| **Cursor IDE users** | Install rules (see below) |
+
+### Claude Code Installation
+
+**Option 1: npx skills CLI**
+```bash
+npx skills add netboxlabs/netbox-best-practices
+```
+
+**Option 2: Manual install**
+```bash
+# Global (all projects)
+cp -r skills/* ~/.claude/skills/
+
+# Or project-local
+cp -r skills/* .claude/skills/
+```
+
+### Cursor IDE Installation
+
+Copy `.cursor/rules/` to your project root:
+```bash
+cp -r .cursor/rules/ /path/to/your/project/.cursor/rules/
+```
+
+Rules are auto-applied based on file patterns. See [Cursor Rules docs](https://cursor.com/docs/context/rules) for details.
 
 ## Available Content
 

--- a/skills/netbox-integration-best-practices/SKILL.md
+++ b/skills/netbox-integration-best-practices/SKILL.md
@@ -1,17 +1,7 @@
 ---
-skill: netbox-integration-best-practices
-version: 1.0.0
-triggers:
-  - netbox
-  - netbox api
-  - netbox integration
-  - netbox rest
-  - netbox graphql
-  - pynetbox
-  - netbox automation
-  - diode
-  - netbox diode
-description: Best practices for building integrations with NetBox REST and GraphQL APIs
+name: netbox-integration-best-practices
+description: Best practices for building integrations with NetBox REST and GraphQL APIs. Use when building NetBox API integrations, reviewing integration code, troubleshooting NetBox performance issues, planning automation architecture, writing scripts that interact with NetBox, using pynetbox, configuring Diode for data ingestion, or implementing NetBox webhooks.
+license: Apache-2.0
 ---
 
 # NetBox Integration Best Practices Skill


### PR DESCRIPTION
## Summary

- Fixes `npx skills add netboxlabs/netbox-best-practices` failing with "No valid skills found"
- The `skills` CLI requires a `name:` field in SKILL.md frontmatter, but we were using `skill:` instead
- Also removes unsupported fields (`version:`, `triggers:`) and expands description for keyword discovery

## Changes

- Rename `skill:` to `name:` (required field)
- Remove `version:` and `triggers:` (unsupported by skills CLI)
- Expand `description:` to include trigger keywords inline for auto-discovery
- Add `license:` field

## Test plan

After merging:
```bash
npx skills add netboxlabs/netbox-best-practices
```

Expected: Skill installs successfully with message "Found 1 skill"

Tested with fork: `npx skills add beevek/netbox-best-practices` now correctly finds and displays the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)