### PR TITLE
Update best practices for NetBox 4.5.2 performance improvements

### DIFF
--- a/.cursor/rules/netbox-graphql.mdc
+++ b/.cursor/rules/netbox-graphql.mdc
@@ -76,10 +76,25 @@ NetBox uses offset pagination which slows as you paginate deeper:
 | Version | Strategy |
 |---------|----------|
 | 4.4.x | Offset only (avoid deep pagination) |
-| 4.5.x | ID range filtering workaround |
-| 4.6.0+ | Cursor-based (`start` param) - [#21110](https://github.com/netbox-community/netbox/issues/21110) |
+| 4.5.0-4.5.1 | ID range filtering workaround |
+| 4.5.2+ | Cursor-based (`start` param) - [#21110](https://github.com/netbox-community/netbox/issues/21110) |
 
-**4.5.x workaround** - Emulate cursors with ID filtering:
+**4.5.2+ cursor-based pagination** - Use the `start` parameter with the primary key:
+
+```graphql
+query GetDevices($startPk: Int, $limit: Int!) {
+  device_list(pagination: { start: $startPk, limit: $limit }) {
+    id  # Track max(id) for next page's start value
+    name
+  }
+}
+```
+
+The `start` parameter yields: `Device.objects.order_by('pk').filter(pk__gte=start)[:limit]`
+
+For the next page, use `start = max(id) + 1` from the previous result.
+
+**4.5.0-4.5.1 workaround** - Emulate cursors with ID filtering:
 
 ```graphql
 query GetDevices($minId: Int!, $limit: Int!) {
@@ -181,6 +196,14 @@ query {
 | Bulk create/update/delete | REST |
 | Complex nested queries | GraphQL (with care) |
 | High-volume reads | REST with brief mode |
+
+## NetBox 4.5.2+ GraphQL Performance Improvements
+
+**Per-Request Caching (4.5.2+)**
+- ObjectType instances are cached per-request ([#21259](https://github.com/netbox-community/netbox/pull/21259))
+- CustomField values are cached per-request ([#21300](https://github.com/netbox-community/netbox/pull/21300))
+
+These improvements significantly reduce duplicate database queries in nested GraphQL queries. When the same object is referenced multiple times in a single query (e.g., the same site appearing across many devices), NetBox now caches the resolved object instead of re-fetching it.
 
 ## References
 

--- a/.cursor/rules/netbox-rest-api.mdc
+++ b/.cursor/rules/netbox-rest-api.mdc
@@ -50,9 +50,23 @@ response = requests.get(
 )
 ```
 
-## Exclude config_context (HIGH)
+## Exclude Expensive Fields (HIGH)
 
-Config context is expensive to compute. Exclude when not needed.
+Config context and local context are expensive to compute. Exclude when not needed.
+
+**4.5.2+ Use `?omit=` Parameter** ([#21244](https://github.com/netbox-community/netbox/pull/21244)):
+
+```python
+# Exclude multiple expensive fields (4.5.2+)
+response = requests.get(
+    f"{API_URL}/dcim/devices/",
+    params={"omit": "config_context,local_context_data"}
+)
+```
+
+The `?omit=` parameter is the inverse of `?fields=` - include everything except the specified fields.
+
+**Pre-4.5.2 Use `?exclude=` Parameter**:
 
 ```python
 response = requests.get(


### PR DESCRIPTION
## Summary

- **GraphQL cursor-based pagination**: The `start` parameter for cursor-based pagination was added in NetBox 4.5.2 (not 4.6.0+ as previously documented). Updated version table and added proper usage examples.
- **GraphQL per-request caching**: Documented the new ObjectType caching (#21259) and CustomField caching (#21300) improvements in 4.5.2
- **REST API `?omit=` parameter**: Added documentation for the new field exclusion parameter (#21244)

## Changes

### GraphQL (`netbox-graphql.mdc`)
- Corrected version table: cursor-based pagination is 4.5.2+ (not 4.6.0+)
- Added proper `pagination: { start: $startPk, limit: $limit }` syntax
- Explained the underlying query behavior
- Added section on 4.5.2+ per-request caching improvements

### REST API (`netbox-rest-api.mdc`)
- Added the new `?omit=` parameter for excluding fields (4.5.2+)
- Kept `?exclude=` documentation for pre-4.5.2 compatibility

## References
- [#21110](https://github.com/netbox-community/netbox/issues/21110) - Cursor-based pagination
- [#21244](https://github.com/netbox-community/netbox/pull/21244) - `?omit=` parameter
- [#21259](https://github.com/netbox-community/netbox/pull/21259) - ObjectType caching
- [#21300](https://github.com/netbox-community/netbox/pull/21300) - CustomField caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)