### PR TITLE
Add NetBox Branching plugin integration best practices

### DIFF
--- a/.cursor/rules/netbox-integration.mdc
+++ b/.cursor/rules/netbox-integration.mdc
@@ -113,6 +113,61 @@ response = requests.get(
 )
 ```
 
+## NetBox Branching Plugin (HIGH)
+
+> Requires [netbox-branching](https://github.com/netboxlabs/netbox-branching) plugin.
+
+### Branch Workflow
+
+```python
+import requests
+import time
+
+# 1. Create branch
+branch_resp = requests.post(
+    f"{API_URL}/plugins/branching/branches/",
+    headers=HEADERS,
+    json={"name": "feature-update", "description": "Updates"}
+)
+branch = branch_resp.json()
+schema_id = branch["schema_id"]  # 8-char ID for header
+
+# 2. Wait for READY state
+while True:
+    b = requests.get(f"{API_URL}/plugins/branching/branches/{branch['id']}/", headers=HEADERS).json()
+    if b["status"]["value"] == "ready":
+        break
+    time.sleep(2)
+
+# 3. Work in branch context
+branch_headers = {**HEADERS, "X-NetBox-Branch": schema_id}
+requests.post(f"{API_URL}/dcim/devices/", headers=branch_headers, json={...})
+
+# 4. Merge (async - returns Job)
+merge_resp = requests.post(
+    f"{API_URL}/plugins/branching/branches/{branch['id']}/merge/",
+    headers=HEADERS,
+    json={"commit": True}  # False for dry-run
+)
+job = merge_resp.json()
+
+# 5. Poll job until complete
+while True:
+    j = requests.get(job["url"], headers=HEADERS).json()
+    if j["status"]["value"] == "completed":
+        break
+    if j["status"]["value"] in ("errored", "failed"):
+        raise RuntimeError(f"Merge failed: {j}")
+    time.sleep(2)
+```
+
+### Key Points
+
+- **Header**: `X-NetBox-Branch: {schema_id}` (8-char ID, not branch name)
+- **States**: NEW → PROVISIONING → READY → MERGING → MERGED
+- **Async ops**: sync/merge/revert return Jobs—always poll
+- **Dry-run**: `{"commit": false}` validates without applying
+
 ## References
 
 See `skills/netbox-integration-best-practices/references/rules/integ-*.md` for detailed rules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ When working on NetBox integrations, follow these key principles:
 ### Integration (`integ-`)
 - Use Diode for high-volume ingestion (HIGH)
 - Use pynetbox for Python integrations (HIGH)
+- Use branching plugin for change management workflows (HIGH) - requires [netbox-branching](https://github.com/netboxlabs/netbox-branching)
 - Configure webhooks for change notifications
 - Query object changes for audit trails
 
@@ -76,3 +77,4 @@ When making changes:
 - [pynetbox](https://github.com/netbox-community/pynetbox) - Official Python client
 - [Diode](https://github.com/netboxlabs/diode) - High-volume data ingestion
 - [netbox-graphql-query-optimizer](https://github.com/netboxlabs/netbox-graphql-query-optimizer)
+- [netbox-branching](https://github.com/netboxlabs/netbox-branching) - Change management plugin

--- a/skills/netbox-integration-best-practices/SKILL.md
+++ b/skills/netbox-integration-best-practices/SKILL.md
@@ -79,6 +79,14 @@ Apply these practices when:
 - Use `pip install netboxlabs-diode-sdk` for Python
 - Use REST/GraphQL API for reading; use Diode for writing/populating
 
+### Branching (Plugin)
+> Requires [netbox-branching](https://github.com/netboxlabs/netbox-branching) plugin.
+
+- **Lifecycle**: Create → Wait (PROVISIONING→READY) → Work → Sync → Merge
+- **Context header**: `X-NetBox-Branch: {schema_id}` (8-char ID, not name)
+- **Async operations**: sync/merge/revert return Job objects—poll for completion
+- **Dry-run**: All async ops accept `{"commit": false}` for validation
+
 ## Rules by Category
 
 ### Authentication Rules
@@ -144,6 +152,9 @@ Apply these practices when:
 |------|--------|-------------|
 | [integ-diode-ingestion](./references/rules/integ-diode-ingestion.md) | HIGH | Use Diode for high-volume data ingestion |
 | [integ-pynetbox-client](./references/rules/integ-pynetbox-client.md) | HIGH | Use pynetbox for Python |
+| [integ-branch-api-workflow](./references/rules/integ-branch-api-workflow.md) | HIGH | Complete branching lifecycle (plugin) |
+| [integ-branch-context-header](./references/rules/integ-branch-context-header.md) | HIGH | Branch context with X-NetBox-Branch header (plugin) |
+| [integ-branch-async-operations](./references/rules/integ-branch-async-operations.md) | MEDIUM | Job polling for sync/merge/revert (plugin) |
 | [integ-webhook-configuration](./references/rules/integ-webhook-configuration.md) | MEDIUM | Configure webhooks |
 | [integ-change-tracking](./references/rules/integ-change-tracking.md) | LOW | Query object changes |
 
@@ -159,6 +170,7 @@ Apply these practices when:
 - [netbox-graphql-query-optimizer](https://github.com/netboxlabs/netbox-graphql-query-optimizer) - Query analysis (essential for GraphQL)
 - [Diode](https://github.com/netboxlabs/diode) - Data ingestion service (for high-volume writes)
 - [Diode Python SDK](https://github.com/netboxlabs/diode-sdk-python) - Python client for Diode
+- [NetBox Branching](https://github.com/netboxlabs/netbox-branching) - Change management plugin (optional)
 
 ### Community
 - [NetBox GitHub](https://github.com/netbox-community/netbox)

--- a/skills/netbox-integration-best-practices/references/rules/_sections.md
+++ b/skills/netbox-integration-best-practices/references/rules/_sections.md
@@ -103,6 +103,9 @@ Rules for integration patterns, tooling, and best practices.
 |------|--------|-------------|
 | [integ-diode-ingestion](./integ-diode-ingestion.md) | HIGH | Use Diode for simplified data ingestion |
 | [integ-pynetbox-client](./integ-pynetbox-client.md) | HIGH | Use pynetbox for Python integrations |
+| [integ-branch-api-workflow](./integ-branch-api-workflow.md) | HIGH | Complete branching lifecycle (plugin required) |
+| [integ-branch-context-header](./integ-branch-context-header.md) | HIGH | Switch context with X-NetBox-Branch header (plugin required) |
+| [integ-branch-async-operations](./integ-branch-async-operations.md) | MEDIUM | Job polling for sync/merge/revert (plugin required) |
 | [integ-webhook-configuration](./integ-webhook-configuration.md) | MEDIUM | Configure webhooks for event-driven integration |
 | [integ-change-tracking](./integ-change-tracking.md) | LOW | Query object changes for audit trails |
 
@@ -119,7 +122,7 @@ Rules for integration patterns, tooling, and best practices.
 | GraphQL | 11 | 2 CRITICAL, 6 HIGH, 2 MEDIUM, 1 LOW |
 | Performance | 2 | 2 HIGH |
 | Data Modeling | 7 | 1 CRITICAL, 6 MEDIUM |
-| Integration | 4 | 2 HIGH, 1 MEDIUM, 1 LOW |
-| **Total** | **38** | **5 CRITICAL, 16 HIGH, 12 MEDIUM, 5 LOW** |
+| Integration | 7 | 4 HIGH, 2 MEDIUM, 1 LOW |
+| **Total** | **41** | **5 CRITICAL, 19 HIGH, 13 MEDIUM, 5 LOW** |
 
 > **Note:** Generic software development best practices (token storage, retry strategies, connection pooling, caching, parallelization, etc.) are intentionally excluded. This skill focuses on NetBox and Diode-specific patterns.

--- a/skills/netbox-integration-best-practices/references/rules/integ-branch-api-workflow.md
+++ b/skills/netbox-integration-best-practices/references/rules/integ-branch-api-workflow.md
@@ -1,0 +1,271 @@
+---
+title: NetBox Branching API Workflow
+impact: HIGH
+category: integ
+tags: [branching, change-management, workflow, api]
+netbox_version: "4.0+"
+---
+
+# integ-branch-api-workflow: NetBox Branching API Workflow
+
+> **Plugin Required:** This rule applies only when the [netbox-branching](https://github.com/netboxlabs/netbox-branching) plugin is installed.
+
+## Rationale
+
+The NetBox Branching plugin enables change management workflows where modifications are made in isolated branches before being merged to main. Understanding the complete branch lifecycle is essential for building reliable automation:
+
+1. **Create branch** - Initialize an isolated workspace
+2. **Wait for provisioning** - Branch schema must be READY before use
+3. **Make changes** - Work in branch context using the `X-NetBox-Branch` header
+4. **Sync (optional)** - Pull latest main changes into your branch
+5. **Merge** - Apply branch changes to main
+
+This workflow prevents conflicts, enables review processes, and provides rollback capability via revert operations.
+
+## Branch Lifecycle States
+
+| State | Description | API Operations Allowed |
+|-------|-------------|----------------------|
+| `NEW` | Just created, not yet provisioned | None |
+| `PROVISIONING` | Schema being created | None |
+| `READY` | Ready for use | Read, write, sync, merge, revert |
+| `SYNCING` | Pulling changes from main | Read only |
+| `MERGING` | Applying changes to main | Read only |
+| `REVERTING` | Rolling back changes | Read only |
+| `MERGED` | Successfully merged | Read only (historical) |
+| `ARCHIVED` | No longer active | None |
+
+## Incorrect Pattern
+
+```python
+# WRONG: Not waiting for branch to be ready before use
+import requests
+
+NETBOX_URL = "https://netbox.example.com"
+HEADERS = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+
+def quick_branch_workflow():
+    # Create branch
+    branch_resp = requests.post(
+        f"{NETBOX_URL}/api/plugins/branching/branches/",
+        headers=HEADERS,
+        json={"name": "feature-update", "description": "Network updates"}
+    )
+    branch = branch_resp.json()
+
+    # WRONG: Using branch immediately without checking state
+    headers_with_branch = {**HEADERS, "X-NetBox-Branch": branch["schema_id"]}
+
+    # This may fail - branch not yet provisioned!
+    requests.post(
+        f"{NETBOX_URL}/api/dcim/devices/",
+        headers=headers_with_branch,
+        json={"name": "new-switch", "site": 1, "device_type": 1, "role": 1}
+    )
+```
+
+**Problems with this approach:**
+- Branch may still be in `PROVISIONING` state
+- API calls will fail with errors about invalid branch context
+- No handling of async operations (sync/merge return Jobs, not immediate results)
+
+## Correct Pattern
+
+```python
+# CORRECT: Complete branch workflow with proper state handling
+import requests
+import time
+
+NETBOX_URL = "https://netbox.example.com"
+HEADERS = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+
+def wait_for_branch_ready(branch_id, timeout=120):
+    """Poll until branch is READY."""
+    start = time.time()
+    while time.time() - start < timeout:
+        resp = requests.get(
+            f"{NETBOX_URL}/api/plugins/branching/branches/{branch_id}/",
+            headers=HEADERS
+        )
+        branch = resp.json()
+        if branch["status"]["value"] == "ready":
+            return branch
+        if branch["status"]["value"] in ("archived", "merged"):
+            raise RuntimeError(f"Branch in terminal state: {branch['status']['value']}")
+        time.sleep(2)
+    raise TimeoutError("Branch did not become ready in time")
+
+
+def wait_for_job(job_url, timeout=300):
+    """Poll until job completes."""
+    start = time.time()
+    while time.time() - start < timeout:
+        resp = requests.get(job_url, headers=HEADERS)
+        job = resp.json()
+        if job["status"]["value"] == "completed":
+            return job
+        if job["status"]["value"] in ("errored", "failed"):
+            raise RuntimeError(f"Job failed: {job.get('error', 'Unknown error')}")
+        time.sleep(2)
+    raise TimeoutError("Job did not complete in time")
+
+
+def branch_workflow():
+    # Step 1: Create branch
+    branch_resp = requests.post(
+        f"{NETBOX_URL}/api/plugins/branching/branches/",
+        headers=HEADERS,
+        json={
+            "name": "feature-network-updates",
+            "description": "Q1 network infrastructure updates"
+        }
+    )
+    branch_resp.raise_for_status()
+    branch = branch_resp.json()
+    branch_id = branch["id"]
+    schema_id = branch["schema_id"]  # 8-char ID for X-NetBox-Branch header
+    print(f"Created branch: {branch['name']} (schema_id: {schema_id})")
+
+    # Step 2: Wait for branch to be READY
+    branch = wait_for_branch_ready(branch_id)
+    print(f"Branch ready: {branch['status']['label']}")
+
+    # Step 3: Make changes in branch context
+    branch_headers = {**HEADERS, "X-NetBox-Branch": schema_id}
+
+    # Create a device in the branch
+    device_resp = requests.post(
+        f"{NETBOX_URL}/api/dcim/devices/",
+        headers=branch_headers,
+        json={
+            "name": "new-switch-01",
+            "site": 1,
+            "device_type": 1,
+            "role": 1,
+            "status": "planned"
+        }
+    )
+    device_resp.raise_for_status()
+    print(f"Created device in branch: {device_resp.json()['name']}")
+
+    # Step 4: Optional - sync latest main changes into branch
+    sync_resp = requests.post(
+        f"{NETBOX_URL}/api/plugins/branching/branches/{branch_id}/sync/",
+        headers=HEADERS,
+        json={"commit": True}  # Use False for dry-run
+    )
+    if sync_resp.status_code == 200:
+        job = sync_resp.json()
+        wait_for_job(job["url"])
+        print("Synced latest main changes into branch")
+
+    # Step 5: Review changes before merge (optional but recommended)
+    diff_resp = requests.get(
+        f"{NETBOX_URL}/api/plugins/branching/branches/{branch_id}/diff/",
+        headers=HEADERS
+    )
+    changes = diff_resp.json()
+    print(f"Changes to merge: {len(changes)} modifications")
+
+    # Step 6: Merge branch to main
+    merge_resp = requests.post(
+        f"{NETBOX_URL}/api/plugins/branching/branches/{branch_id}/merge/",
+        headers=HEADERS,
+        json={"commit": True}  # Use False for dry-run validation
+    )
+    merge_resp.raise_for_status()
+    job = merge_resp.json()
+    wait_for_job(job["url"])
+    print("Branch merged successfully!")
+
+    return branch
+
+
+if __name__ == "__main__":
+    branch_workflow()
+```
+
+**Benefits:**
+- Proper state transitions prevent race conditions
+- Timeout handling prevents infinite waits
+- Dry-run capability (`commit: False`) for validation before committing
+- Clear error handling for failed jobs
+- ChangeDiff review before merge
+
+## Dry-Run Validation
+
+Always validate complex changes with dry-run before committing:
+
+```python
+def merge_with_validation(branch_id):
+    """Dry-run first, then merge if clean."""
+
+    # Dry-run to check for conflicts
+    dry_run_resp = requests.post(
+        f"{NETBOX_URL}/api/plugins/branching/branches/{branch_id}/merge/",
+        headers=HEADERS,
+        json={"commit": False}  # Dry-run mode
+    )
+    dry_run_resp.raise_for_status()
+    dry_run_job = dry_run_resp.json()
+
+    # Wait for dry-run to complete
+    job = wait_for_job(dry_run_job["url"])
+
+    # Check for conflicts in job output
+    if job.get("data", {}).get("conflicts"):
+        print(f"Conflicts detected: {job['data']['conflicts']}")
+        return False
+
+    # No conflicts - proceed with actual merge
+    merge_resp = requests.post(
+        f"{NETBOX_URL}/api/plugins/branching/branches/{branch_id}/merge/",
+        headers=HEADERS,
+        json={"commit": True}
+    )
+    merge_resp.raise_for_status()
+    job = wait_for_job(merge_resp.json()["url"])
+    return True
+```
+
+## pynetbox Example
+
+pynetbox supports branching via its plugin API:
+
+```python
+import pynetbox
+import time
+
+nb = pynetbox.api("https://netbox.example.com", token=TOKEN)
+
+# Create branch
+branch = nb.plugins.branching.branches.create(
+    name="feature-updates",
+    description="Infrastructure updates"
+)
+
+# Wait for ready
+while branch.status.value != "ready":
+    time.sleep(2)
+    branch = nb.plugins.branching.branches.get(branch.id)
+
+# Work in branch context - pynetbox doesn't directly support
+# X-NetBox-Branch header, so use requests for branch operations
+# or create a custom session wrapper (see integ-branch-context-header)
+```
+
+## Exceptions
+
+- **Simple changes**: For single object updates that don't need review, direct API may be simpler
+- **Emergency changes**: In urgent situations, you may need to bypass branching workflow
+- **Read-only operations**: Branching is for writes; reads don't require branch context
+
+## Related Rules
+
+- [integ-branch-context-header](./integ-branch-context-header.md) - Working in branch context
+- [integ-branch-async-operations](./integ-branch-async-operations.md) - Handling async jobs
+
+## References
+
+- [NetBox Branching Plugin](https://github.com/netboxlabs/netbox-branching)
+- [NetBox Branching Documentation](https://netboxlabs.com/docs/netbox-branching/)

--- a/skills/netbox-integration-best-practices/references/rules/integ-branch-async-operations.md
+++ b/skills/netbox-integration-best-practices/references/rules/integ-branch-async-operations.md
@@ -1,0 +1,372 @@
+---
+title: NetBox Branching Async Operations
+impact: MEDIUM
+category: integ
+tags: [branching, async, jobs, polling]
+netbox_version: "4.0+"
+---
+
+# integ-branch-async-operations: NetBox Branching Async Operations
+
+> **Plugin Required:** This rule applies only when the [netbox-branching](https://github.com/netboxlabs/netbox-branching) plugin is installed.
+
+## Rationale
+
+Branch operations that modify significant data (sync, merge, revert) run asynchronously and return Job objects. Understanding how to poll for job completion is essential for reliable automation:
+
+1. **Sync** - Pulls latest main changes into branch (async)
+2. **Merge** - Applies branch changes to main (async)
+3. **Revert** - Rolls back branch changes (async)
+
+Each operation returns a Job object with a URL to poll for status. Jobs progress through states and may succeed or fail.
+
+## Job Status Values
+
+| Status | Description | Terminal? |
+|--------|-------------|-----------|
+| `pending` | Job queued, not yet started | No |
+| `scheduled` | Job scheduled for execution | No |
+| `running` | Job currently executing | No |
+| `completed` | Job finished successfully | Yes |
+| `errored` | Job failed with error | Yes |
+| `failed` | Job failed | Yes |
+
+## Incorrect Pattern
+
+```python
+# WRONG: Not handling async nature of branch operations
+import requests
+
+NETBOX_URL = "https://netbox.example.com"
+HEADERS = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+
+def merge_branch_wrong(branch_id):
+    # WRONG: Assuming merge completes immediately
+    merge_resp = requests.post(
+        f"{NETBOX_URL}/api/plugins/branching/branches/{branch_id}/merge/",
+        headers=HEADERS,
+        json={"commit": True}
+    )
+
+    # This response is a Job, not the merge result!
+    result = merge_resp.json()
+
+    # WRONG: Assuming merge is complete
+    print("Merge complete!")  # Not true - merge is still running!
+
+    # WRONG: Immediately trying to read merged data
+    # Data may not be visible yet
+    devices = requests.get(f"{NETBOX_URL}/api/dcim/devices/").json()
+```
+
+**Problems with this approach:**
+- Merge/sync/revert operations return Jobs, not immediate results
+- Assuming completion leads to race conditions
+- No error handling for failed jobs
+- Data may not be available until job completes
+
+## Correct Pattern
+
+```python
+# CORRECT: Proper async job handling
+import requests
+import time
+from typing import Optional
+
+NETBOX_URL = "https://netbox.example.com"
+HEADERS = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+
+def poll_job(job_url: str, timeout: int = 300, interval: int = 2) -> dict:
+    """
+    Poll a job URL until completion or timeout.
+
+    Args:
+        job_url: Full URL to the job resource
+        timeout: Maximum seconds to wait
+        interval: Seconds between polls
+
+    Returns:
+        Completed job object
+
+    Raises:
+        RuntimeError: If job fails or errors
+        TimeoutError: If job doesn't complete in time
+    """
+    start = time.time()
+
+    while time.time() - start < timeout:
+        resp = requests.get(job_url, headers=HEADERS)
+        resp.raise_for_status()
+        job = resp.json()
+
+        status = job["status"]["value"]
+
+        if status == "completed":
+            return job
+
+        if status in ("errored", "failed"):
+            error_msg = job.get("data", {}).get("error", "Unknown error")
+            raise RuntimeError(f"Job failed: {error_msg}")
+
+        # Job still in progress
+        time.sleep(interval)
+
+    raise TimeoutError(f"Job did not complete within {timeout} seconds")
+
+
+def merge_branch(branch_id: int, dry_run: bool = False) -> dict:
+    """
+    Merge a branch to main with proper async handling.
+
+    Args:
+        branch_id: Branch numeric ID
+        dry_run: If True, validate without committing
+
+    Returns:
+        Completed job object
+    """
+    resp = requests.post(
+        f"{NETBOX_URL}/api/plugins/branching/branches/{branch_id}/merge/",
+        headers=HEADERS,
+        json={"commit": not dry_run}
+    )
+    resp.raise_for_status()
+
+    job = resp.json()
+    print(f"Merge job started: {job['url']}")
+
+    # Poll until complete
+    return poll_job(job["url"])
+
+
+def sync_branch(branch_id: int, dry_run: bool = False) -> dict:
+    """
+    Sync main changes into branch with proper async handling.
+
+    Args:
+        branch_id: Branch numeric ID
+        dry_run: If True, show changes without applying
+
+    Returns:
+        Completed job object
+    """
+    resp = requests.post(
+        f"{NETBOX_URL}/api/plugins/branching/branches/{branch_id}/sync/",
+        headers=HEADERS,
+        json={"commit": not dry_run}
+    )
+    resp.raise_for_status()
+
+    job = resp.json()
+    print(f"Sync job started: {job['url']}")
+
+    return poll_job(job["url"])
+
+
+def revert_branch(branch_id: int, dry_run: bool = False) -> dict:
+    """
+    Revert branch changes with proper async handling.
+
+    Args:
+        branch_id: Branch numeric ID
+        dry_run: If True, show what would be reverted
+
+    Returns:
+        Completed job object
+    """
+    resp = requests.post(
+        f"{NETBOX_URL}/api/plugins/branching/branches/{branch_id}/revert/",
+        headers=HEADERS,
+        json={"commit": not dry_run}
+    )
+    resp.raise_for_status()
+
+    job = resp.json()
+    print(f"Revert job started: {job['url']}")
+
+    return poll_job(job["url"])
+
+
+# Usage example
+try:
+    # Dry-run first to validate
+    dry_run_job = merge_branch(branch_id=42, dry_run=True)
+    print(f"Dry-run passed, changes: {dry_run_job.get('data', {})}")
+
+    # Actual merge
+    merge_job = merge_branch(branch_id=42, dry_run=False)
+    print("Merge completed successfully!")
+
+except RuntimeError as e:
+    print(f"Operation failed: {e}")
+except TimeoutError as e:
+    print(f"Operation timed out: {e}")
+```
+
+**Benefits:**
+- Proper handling of async job lifecycle
+- Clear timeout handling prevents hanging scripts
+- Dry-run validation before committing
+- Error details extracted from job data
+
+## Async Pattern with Callbacks
+
+For long-running operations or event-driven architectures:
+
+```python
+import requests
+import threading
+import time
+from typing import Callable, Optional
+
+def poll_job_async(
+    job_url: str,
+    on_complete: Callable[[dict], None],
+    on_error: Callable[[Exception], None],
+    timeout: int = 300,
+    interval: int = 2
+) -> threading.Thread:
+    """
+    Poll job in background thread, call callbacks on completion.
+
+    Args:
+        job_url: Full URL to the job resource
+        on_complete: Called with job object on success
+        on_error: Called with exception on failure
+        timeout: Maximum seconds to wait
+        interval: Seconds between polls
+
+    Returns:
+        Thread object (already started)
+    """
+    def poll():
+        try:
+            result = poll_job(job_url, timeout, interval)
+            on_complete(result)
+        except Exception as e:
+            on_error(e)
+
+    thread = threading.Thread(target=poll, daemon=True)
+    thread.start()
+    return thread
+
+
+# Usage with callbacks
+def handle_merge_complete(job):
+    print(f"Merge completed: {job['id']}")
+    # Trigger downstream workflows...
+
+def handle_merge_error(error):
+    print(f"Merge failed: {error}")
+    # Alert, retry, or rollback...
+
+# Start merge and poll in background
+merge_resp = requests.post(
+    f"{NETBOX_URL}/api/plugins/branching/branches/42/merge/",
+    headers=HEADERS,
+    json={"commit": True}
+)
+job = merge_resp.json()
+
+thread = poll_job_async(
+    job["url"],
+    on_complete=handle_merge_complete,
+    on_error=handle_merge_error
+)
+
+# Continue with other work...
+print("Merge started, continuing with other tasks...")
+
+# Wait for completion if needed
+thread.join()
+```
+
+## Merge Strategies
+
+When merging, you can specify conflict resolution strategies:
+
+```python
+def merge_with_strategy(branch_id: int, strategy: str = "ours") -> dict:
+    """
+    Merge with specified conflict strategy.
+
+    Args:
+        branch_id: Branch numeric ID
+        strategy: Conflict resolution - "ours" (branch wins) or "theirs" (main wins)
+
+    Returns:
+        Completed job object
+    """
+    resp = requests.post(
+        f"{NETBOX_URL}/api/plugins/branching/branches/{branch_id}/merge/",
+        headers=HEADERS,
+        json={
+            "commit": True,
+            "strategy": strategy  # How to resolve conflicts
+        }
+    )
+    resp.raise_for_status()
+    return poll_job(resp.json()["url"])
+
+
+# Example: Branch changes take priority
+merge_job = merge_with_strategy(42, strategy="ours")
+```
+
+## Checking Job Progress
+
+For long-running operations, provide progress feedback:
+
+```python
+def poll_job_with_progress(job_url: str, timeout: int = 300) -> dict:
+    """Poll job with progress output."""
+    start = time.time()
+    last_status = None
+
+    while time.time() - start < timeout:
+        resp = requests.get(job_url, headers=HEADERS)
+        job = resp.json()
+
+        status = job["status"]["value"]
+
+        # Print status changes
+        if status != last_status:
+            elapsed = int(time.time() - start)
+            print(f"[{elapsed}s] Job status: {status}")
+            last_status = status
+
+        if status == "completed":
+            return job
+
+        if status in ("errored", "failed"):
+            raise RuntimeError(f"Job failed: {job.get('data', {}).get('error')}")
+
+        time.sleep(2)
+
+    raise TimeoutError(f"Job timed out after {timeout}s")
+
+
+# Usage
+job = poll_job_with_progress(job_url, timeout=600)
+# Output:
+# [0s] Job status: pending
+# [2s] Job status: running
+# [45s] Job status: completed
+```
+
+## Exceptions
+
+- **Small branches**: Very small merges may complete almost instantly, but always poll anyway
+- **Dry-run only**: Dry-runs still return jobs but typically complete faster
+- **Network issues**: Consider retry logic for transient poll failures
+
+## Related Rules
+
+- [integ-branch-api-workflow](./integ-branch-api-workflow.md) - Complete branch lifecycle
+- [integ-branch-context-header](./integ-branch-context-header.md) - Branch context switching
+
+## References
+
+- [NetBox Branching Plugin](https://github.com/netboxlabs/netbox-branching)
+- [NetBox Branching Documentation](https://netboxlabs.com/docs/netbox-branching/)
+- [NetBox Jobs Framework](https://netboxlabs.com/docs/netbox/en/stable/features/background-jobs/)

--- a/skills/netbox-integration-best-practices/references/rules/integ-branch-context-header.md
+++ b/skills/netbox-integration-best-practices/references/rules/integ-branch-context-header.md
@@ -1,0 +1,272 @@
+---
+title: NetBox Branch Context Header
+impact: HIGH
+category: integ
+tags: [branching, context, header, api]
+netbox_version: "4.0+"
+---
+
+# integ-branch-context-header: NetBox Branch Context Header
+
+> **Plugin Required:** This rule applies only when the [netbox-branching](https://github.com/netboxlabs/netbox-branching) plugin is installed.
+
+## Rationale
+
+When working with NetBox Branching, you switch between main and branch contexts using the `X-NetBox-Branch` header. This header tells NetBox which schema to use for the request:
+
+- **Without header**: Operations target main database
+- **With header**: Operations target branch schema
+
+The header value is the `schema_id` (8-character identifier) from the branch object, NOT the branch name or numeric ID. This is a common source of confusion.
+
+## Header Format
+
+```
+X-NetBox-Branch: {schema_id}
+```
+
+Where `schema_id` is the 8-character alphanumeric identifier returned when creating a branch:
+
+```python
+branch = {
+    "id": 42,              # Numeric ID - NOT for header
+    "name": "feature-x",   # Human name - NOT for header
+    "schema_id": "a1b2c3d4" # USE THIS for X-NetBox-Branch header
+}
+```
+
+## Incorrect Pattern
+
+```python
+# WRONG: Using wrong identifier for branch header
+import requests
+
+NETBOX_URL = "https://netbox.example.com"
+HEADERS = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+
+# Get branch
+branch_resp = requests.get(
+    f"{NETBOX_URL}/api/plugins/branching/branches/42/",
+    headers=HEADERS
+)
+branch = branch_resp.json()
+
+# WRONG: Using numeric ID
+bad_headers_1 = {**HEADERS, "X-NetBox-Branch": str(branch["id"])}  # 42 - WRONG
+
+# WRONG: Using branch name
+bad_headers_2 = {**HEADERS, "X-NetBox-Branch": branch["name"]}  # "feature-x" - WRONG
+
+# WRONG: Forgetting header entirely for branch operations
+requests.post(
+    f"{NETBOX_URL}/api/dcim/devices/",
+    headers=HEADERS,  # No branch header - goes to main!
+    json={...}
+)
+```
+
+**Problems with this approach:**
+- Using wrong identifier causes "Invalid branch" errors
+- Missing header causes changes to go to main instead of branch
+- No way to know which context you're operating in without explicit tracking
+
+## Correct Pattern
+
+```python
+# CORRECT: Using schema_id for branch context
+import requests
+
+NETBOX_URL = "https://netbox.example.com"
+HEADERS = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+
+def get_branch_headers(schema_id):
+    """Create headers with branch context."""
+    return {**HEADERS, "X-NetBox-Branch": schema_id}
+
+
+# Create branch and extract schema_id
+branch_resp = requests.post(
+    f"{NETBOX_URL}/api/plugins/branching/branches/",
+    headers=HEADERS,
+    json={"name": "feature-updates", "description": "Q1 updates"}
+)
+branch = branch_resp.json()
+schema_id = branch["schema_id"]  # e.g., "a1b2c3d4"
+
+# Wait for branch ready (see integ-branch-api-workflow)
+# ...
+
+# Create headers for branch context
+branch_headers = get_branch_headers(schema_id)
+
+# Operations in branch context
+device_resp = requests.post(
+    f"{NETBOX_URL}/api/dcim/devices/",
+    headers=branch_headers,
+    json={"name": "new-switch", "site": 1, "device_type": 1, "role": 1}
+)
+
+# Read from branch - device exists only in branch
+branch_device = requests.get(
+    f"{NETBOX_URL}/api/dcim/devices/",
+    headers=branch_headers,
+    params={"name": "new-switch"}
+).json()  # Found in branch
+
+# Read from main - device doesn't exist yet
+main_device = requests.get(
+    f"{NETBOX_URL}/api/dcim/devices/",
+    headers=HEADERS,  # No branch header = main
+    params={"name": "new-switch"}
+).json()  # Not found in main (until merged)
+```
+
+**Benefits:**
+- Clear separation between main and branch contexts
+- Explicit control over which schema receives changes
+- Easy to verify context before critical operations
+
+## Session Wrapper Pattern
+
+For complex workflows, wrap the branch context in a session helper:
+
+```python
+import requests
+
+class BranchSession:
+    """Context manager for working in a NetBox branch."""
+
+    def __init__(self, netbox_url, token, schema_id):
+        self.netbox_url = netbox_url.rstrip("/")
+        self.schema_id = schema_id
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "X-NetBox-Branch": schema_id,
+        })
+
+    def get(self, endpoint, **kwargs):
+        """GET request in branch context."""
+        url = f"{self.netbox_url}/api/{endpoint.lstrip('/')}"
+        return self.session.get(url, **kwargs)
+
+    def post(self, endpoint, **kwargs):
+        """POST request in branch context."""
+        url = f"{self.netbox_url}/api/{endpoint.lstrip('/')}"
+        return self.session.post(url, **kwargs)
+
+    def patch(self, endpoint, **kwargs):
+        """PATCH request in branch context."""
+        url = f"{self.netbox_url}/api/{endpoint.lstrip('/')}"
+        return self.session.patch(url, **kwargs)
+
+    def delete(self, endpoint, **kwargs):
+        """DELETE request in branch context."""
+        url = f"{self.netbox_url}/api/{endpoint.lstrip('/')}"
+        return self.session.delete(url, **kwargs)
+
+
+# Usage
+branch_session = BranchSession(
+    netbox_url="https://netbox.example.com",
+    token=TOKEN,
+    schema_id="a1b2c3d4"
+)
+
+# All operations use branch context
+devices = branch_session.get("dcim/devices/", params={"site": "nyc"}).json()
+new_device = branch_session.post("dcim/devices/", json={...}).json()
+```
+
+## Comparing Branch and Main
+
+A common pattern is comparing what exists in branch vs main:
+
+```python
+def compare_branch_main(endpoint, params, schema_id):
+    """Compare query results between branch and main."""
+
+    # Query main
+    main_resp = requests.get(
+        f"{NETBOX_URL}/api/{endpoint}/",
+        headers=HEADERS,
+        params=params
+    )
+    main_results = main_resp.json()["results"]
+
+    # Query branch
+    branch_headers = {**HEADERS, "X-NetBox-Branch": schema_id}
+    branch_resp = requests.get(
+        f"{NETBOX_URL}/api/{endpoint}/",
+        headers=branch_headers,
+        params=params
+    )
+    branch_results = branch_resp.json()["results"]
+
+    # Find differences
+    main_ids = {r["id"] for r in main_results}
+    branch_ids = {r["id"] for r in branch_results}
+
+    return {
+        "added_in_branch": branch_ids - main_ids,
+        "deleted_in_branch": main_ids - branch_ids,
+        "in_both": main_ids & branch_ids,
+    }
+
+
+# Example: Find new devices in branch
+diff = compare_branch_main("dcim/devices", {"site": "nyc"}, schema_id)
+print(f"New devices in branch: {diff['added_in_branch']}")
+```
+
+## GraphQL with Branch Context
+
+The branch header works with GraphQL queries too:
+
+```python
+def graphql_in_branch(query, variables, schema_id):
+    """Execute GraphQL query in branch context."""
+    headers = {
+        "Authorization": f"Bearer {TOKEN}",
+        "Content-Type": "application/json",
+        "X-NetBox-Branch": schema_id,
+    }
+
+    resp = requests.post(
+        f"{NETBOX_URL}/graphql/",
+        headers=headers,
+        json={"query": query, "variables": variables}
+    )
+    return resp.json()
+
+
+# Query devices in branch
+query = """
+query BranchDevices($site_id: Int!) {
+    device_list(filters: {site_id: $site_id}, limit: 100) {
+        name
+        status
+        primary_ip4 { address }
+    }
+}
+"""
+
+result = graphql_in_branch(query, {"site_id": 1}, schema_id)
+```
+
+## Exceptions
+
+- **Read-only queries**: For queries that don't need isolation, you can query main directly
+- **Cross-branch comparison**: Some operations require querying both contexts
+- **Merge/sync operations**: These use the branch numeric ID, not schema_id, in the URL path
+
+## Related Rules
+
+- [integ-branch-api-workflow](./integ-branch-api-workflow.md) - Complete branch lifecycle
+- [integ-branch-async-operations](./integ-branch-async-operations.md) - Async job handling
+
+## References
+
+- [NetBox Branching Plugin](https://github.com/netboxlabs/netbox-branching)
+- [NetBox Branching Documentation](https://netboxlabs.com/docs/netbox-branching/)


### PR DESCRIPTION
## Summary

- Add 3 workflow-oriented rules for the [netbox-branching](https://github.com/netboxlabs/netbox-branching) plugin
- Update all content formats (Claude Skills, Cursor Rules, Human docs) per repository conventions
- Rule count increased from 38 to 41

### New Rules

| Rule | Impact | Description |
|------|--------|-------------|
| `integ-branch-api-workflow` | HIGH | Complete lifecycle: create → wait → work → sync → merge |
| `integ-branch-context-header` | HIGH | Using `X-NetBox-Branch: {schema_id}` header for context switching |
| `integ-branch-async-operations` | MEDIUM | Job polling patterns for sync/merge/revert operations |

### Key Technical Details

- **Header format**: `X-NetBox-Branch: {schema_id}` (8-char ID from branch object)
- **Lifecycle states**: NEW → PROVISIONING → READY → (SYNCING/MERGING) → MERGED → ARCHIVED
- **Async operations**: sync/merge/revert return Job objects that must be polled
- **Dry-run support**: All async ops accept `{"commit": false}` for validation

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)